### PR TITLE
Rewrite NFC iOS libs messages as localization keys for future reuse.

### DIFF
--- a/nfc-lib/nfc-lib/nfclib/Operations/NFCConnection.swift
+++ b/nfc-lib/nfc-lib/nfclib/Operations/NFCConnection.swift
@@ -26,24 +26,24 @@ import CryptoTokenKit
 public class NFCConnection {
     func setup(_ session: NFCTagReaderSession, tags: [NFCTag]) async throws -> NFCISO7816Tag {
         if tags.count > 1 {
-            session.invalidate(errorMessage: "Andmete lugemine ebaõnnestus")
+            session.invalidate(errorMessage: "Failed to read data")
             throw IdCardInternalError.multipleTagsDetected
         }
 
         guard let firstTag = tags.first else {
-            session.invalidate(errorMessage: "Andmete lugemine ebaõnnestus")
+            session.invalidate(errorMessage: "Failed to read data")
             throw IdCardInternalError.invalidTag
         }
 
         do {
             try await session.connect(to: firstTag)
         } catch {
-            session.invalidate(errorMessage: "Andmete lugemine ebaõnnestus")
+            session.invalidate(errorMessage: "Failed to read data")
             throw IdCardInternalError.connectionFailed
         }
 
         guard case let .iso7816(tag) = firstTag else {
-            session.invalidate(errorMessage: "Andmete lugemine ebaõnnestus")
+            session.invalidate(errorMessage: "Failed to read data")
             throw IdCardInternalError.invalidTag
         }
 

--- a/nfc-lib/nfc-lib/nfclib/Operations/OperationReadCertificate.swift
+++ b/nfc-lib/nfc-lib/nfclib/Operations/OperationReadCertificate.swift
@@ -47,8 +47,7 @@ public class OperationReadCertificate: NSObject {
     private var session: NFCTagReaderSession?
     private var CAN: String = ""
     private var certUsage: CertificateUsage!
-    // TODO: Use a proper message that is localised
-    private let nfcMessage: String = "Palun asetage oma ID-kaart vastu nutiseadet."
+    private let nfcMessage: String = "Please place your ID card against the smart device"
     private let connection = NFCConnection()
     private var continuation: CheckedContinuation<SecCertificate, Error>?
 
@@ -80,11 +79,11 @@ extension OperationReadCertificate: NFCTagReaderSessionDelegate {
 
             guard let certUsage else {
                 continuation?.resume(throwing: ReadCertificateError.certificateUsageNotSpecified)
-                session.invalidate(errorMessage: "Andmete lugemine ebaõnnestus")
+                session.invalidate(errorMessage: "Failed to read data")
                 return
             }
             do {
-                session.alertMessage = "Hoidke ID-kaarti vastu nutiseadet kuni andmeid loetakse."
+                session.alertMessage = "Hold your ID card against your smart device until the data is read"
                 let tag = try await connection.setup(session, tags: tags)
                 let cardCommands = try await connection.getCardCommands(session, tag: tag, CAN: CAN)
                 do {
@@ -98,14 +97,14 @@ extension OperationReadCertificate: NFCTagReaderSessionDelegate {
                         let x509Certificate = try convertBytesToX509Certificate(cert)
                         continuation?.resume(with: .success(x509Certificate))
                     }
-                    session.alertMessage = "Andmed loetud"
+                    session.alertMessage = "Data read"
                     session.invalidate()
                 } catch {
-                    session.invalidate(errorMessage: "Andmete lugemine ebaõnnestus")
+                    session.invalidate(errorMessage: "Failed to read data")
                     continuation?.resume(throwing: ReadCertificateError.failedToReadCertificate)
                 }
             } catch {
-                session.invalidate(errorMessage: "Andmete lugemine ebaõnnestus")
+                session.invalidate(errorMessage: "Failed to read data")
                 continuation?.resume(throwing: error)
             }
         }

--- a/nfc-lib/nfc-lib/nfclib/Operations/OperationReadPublicData.swift
+++ b/nfc-lib/nfc-lib/nfclib/Operations/OperationReadPublicData.swift
@@ -27,8 +27,7 @@ import BigInt
 @MainActor final public class OperationReadPublicData: NSObject {
     private var session: NFCTagReaderSession?
     private var CAN: String = ""
-    // TODO: Use a proper message that is localised
-    private let nfcMessage: String = "Palun asetage oma ID-kaart vastu nutiseadet."
+    private let nfcMessage: String = "Please place your ID card against the smart device"
     private let connection = NFCConnection()
     private var continuation: CheckedContinuation<CardInfo, Error>?
 
@@ -53,16 +52,16 @@ extension OperationReadPublicData: @MainActor NFCTagReaderSessionDelegate {
     public func tagReaderSession(_ session: NFCTagReaderSession, didDetect tags: [NFCTag]) {
         Task {
             do {
-                session.alertMessage = "Hoidke ID-kaarti vastu nutiseadet kuni andmeid loetakse."
+                session.alertMessage = "Hold your ID card against your smart device until the data is read"
                 let tag = try await connection.setup(session, tags: tags)
                 let cardCommands = try await connection.getCardCommands(session, tag: tag, CAN: CAN)
                 let cardInfo = try await cardCommands.readPublicData()
 
                 continuation?.resume(with: .success(cardInfo))
-                session.alertMessage = "Andmed loetud"
+                session.alertMessage = "Data read"
                 session.invalidate()
             } catch {
-                session.invalidate(errorMessage: "Andmete lugemine ebaõnnestus")
+                session.invalidate(errorMessage: "Failed to read data")
                 continuation?.resume(throwing: error)
             }
         }

--- a/nfc-lib/nfc-lib/nfclib/Operations/OperationSignHash.swift
+++ b/nfc-lib/nfc-lib/nfclib/Operations/OperationSignHash.swift
@@ -31,7 +31,7 @@ public class OperationSignHash: NSObject {
     private var CAN: String = ""
     private var PIN: SecureData = SecureData([0x00])
     private var hashToSign: Data?
-    private let nfcMessage: String = "Palun asetage oma ID-kaart vastu nutiseadet."
+    private let nfcMessage: String = "Please place your ID card against the smart device"
     private var continuation: CheckedContinuation<Data, Error>?
     private var connection = NFCConnection()
 
@@ -56,10 +56,10 @@ public class OperationSignHash: NSObject {
 
     private func updateAlertMessage(step: Int) {
         let stepMessages = [
-            "Palun asetage oma ID-kaart vastu nutiseadet.",
-            "Hoidke ID-kaarti vastu nutiseadet kuni andmeid loetakse.",
-            "Andmete lugemine käib, palun oodake.",
-            "Signeerimine käib, palun oodake."
+            "Please place your ID card against the smart device",
+            "Hold your ID card against your smart device until the data is read",
+            "Reading data please wait",
+            "Signing in progress please wait"
         ]
 
         let stepMessage = stepMessages[min(step, stepMessages.count - 1)]
@@ -85,10 +85,10 @@ extension OperationSignHash: @MainActor NFCTagReaderSessionDelegate {
                 updateAlertMessage(step: 3)
                 let signatureValue = try await cardCommands.calculateSignature(for: hashToSign, withPin2: PIN)
                 continuation?.resume(with: .success(signatureValue))
-                session.alertMessage = "Andmed loetud"
+                session.alertMessage = "Data read"
                 session.invalidate()
             } catch {
-                session.invalidate(errorMessage: "Andmete lugemine ebaõnnestus")
+                session.invalidate(errorMessage: "Failed to read data")
                 continuation?.resume(throwing: error)
             }
         }

--- a/nfc-lib/nfc-lib/nfclib/Operations/OperationUnblockPin.swift
+++ b/nfc-lib/nfc-lib/nfclib/Operations/OperationUnblockPin.swift
@@ -38,7 +38,7 @@ public class OperationUnblockPin: NSObject {
     private var codeType: CodeType?
     private var puk: SecureData?
     private var newPin: SecureData?
-    private let nfcMessage: String = "Palun asetage oma ID-kaart vastu nutiseadet."
+    private let nfcMessage: String = "Please place your ID card against the smart device"
     private let connection = NFCConnection()
     private var continuation: CheckedContinuation<Void, Error>?
 
@@ -73,11 +73,11 @@ extension OperationUnblockPin: @MainActor NFCTagReaderSessionDelegate {
 
             guard let codeType = self.codeType, let puk = self.puk, let newPin = self.newPin else {
                 self.continuation?.resume(throwing: UnblockPINError.missingRequiredParameter)
-                session.invalidate(errorMessage: "PINi vahetamine ebaõnnestus")
+                session.invalidate(errorMessage: "PIN change failed")
                 return
             }
             do {
-                session.alertMessage = "Hoidke ID-kaarti vastu nutiseadet kuni andmeid loetakse."
+                session.alertMessage = "Hold your ID card against your smart device until the data is read"
                 let tag = try await self.connection.setup(session, tags: tags)
                 let cardCommands = try await self.connection.getCardCommands(session, tag: tag, CAN: self.CAN)
                 do {
@@ -87,10 +87,10 @@ extension OperationUnblockPin: @MainActor NFCTagReaderSessionDelegate {
                 }
 
                 self.continuation?.resume(with: .success(()))
-                session.alertMessage = "PIN vahetatud"
+                session.alertMessage = "PIN changed"
                 session.invalidate()
             } catch {
-                session.invalidate(errorMessage: "PINi vahetamine ebaõnnestus")
+                session.invalidate(errorMessage: "PIN change failed")
                 self.continuation?.resume(throwing: error)
             }
         }

--- a/nfc-lib/nfc-lib/nfclib/WebEID/OperationAuthenticateWithWebEID.swift
+++ b/nfc-lib/nfc-lib/nfclib/WebEID/OperationAuthenticateWithWebEID.swift
@@ -57,12 +57,10 @@ public class OperationAuthenticateWithWebEID: NSObject {
         return try await withCheckedThrowingContinuation { continuation in
             self.continuation = continuation
             guard NFCTagReaderSession.readingAvailable else {
-                // TODO: Handle this case properly
                 continuation.resume(throwing: IdCardInternalError.nfcNotSupported)
                 return
             }
             session = NFCTagReaderSession(pollingOption: .iso14443, delegate: self)
-            // TODO: Use a proper message that is localised
             updateAlertMessage(step: 0)
             session?.begin()
         }
@@ -70,10 +68,10 @@ public class OperationAuthenticateWithWebEID: NSObject {
 
     private func updateAlertMessage(step: Int) {
         let stepMessages = [
-            "Palun asetage oma ID-kaart vastu nutiseadet.",
-            "Hoidke ID-kaarti vastu nutiseadet kuni andmeid loetakse.",
-            "Andmete lugemine käib, palun oodake.",
-            "Autentimine käib, palun oodake."
+            "Please place your ID card against the smart device",
+            "Hold your ID card against your smart device until the data is read",
+            "Reading data please wait",
+            "Authentication in progress please wait"
         ]
 
         let stepMessage = stepMessages[min(step, stepMessages.count - 1)]
@@ -112,30 +110,28 @@ extension OperationAuthenticateWithWebEID: @MainActor NFCTagReaderSessionDelegat
                 let notBefore = certificate.notValidBefore
 
                 guard Date() >= notBefore else {
-                    let errorMessage = "Sertifikaat pole veel kehtiv"
+                    let errorMessage = "Certificate not yet valid"
                     session.invalidate(errorMessage: errorMessage)
                     continuation?.resume(throwing: AuthenticateWithWebEidError.failedCertificateNotYetValid)
                     return
                 }
 
                 guard Date() <= notAfter else {
-                    let errorMessage = "Sertifikaat on aegunud"
+                    let errorMessage = "Certificate has expired"
                     session.invalidate(errorMessage: errorMessage)
                     continuation?.resume(throwing: AuthenticateWithWebEidError.failedCertificateExpired)
                     return
                 }
 
                 guard let publicKey = SecCertificateCopyKey(authCertificate) else {
-                    // TODO: Failed to process public key, handle error
-                    let errorMessage = "Andmete lugemine ebaõnnestus"
+                    let errorMessage = "Failed to read data"
                     session.invalidate(errorMessage: errorMessage)
                     continuation?.resume(throwing: AuthenticateWithWebEidError.failedToReadPublicKey)
                     return
                 }
 
                 guard let keyAlgorithmData = getAlgorithmNameTypeAndLength(from: publicKey) else {
-                    // TODO: Implement error handling
-                    let errorMessage = "Andmete lugemine ebaõnnestus"
+                    let errorMessage = "Failed to read data"
                     session.invalidate(errorMessage: errorMessage)
                     continuation?.resume(throwing: AuthenticateWithWebEidError.failedToDetermineAlgorithm)
                     return
@@ -148,7 +144,7 @@ extension OperationAuthenticateWithWebEID: @MainActor NFCTagReaderSessionDelegat
                       let challengeHash = sha(hashLength: hashLength, data: challengeData),
                       let webEidHash = sha(hashLength: hashLength, data: originHash + challengeHash)
                 else {
-                    let errorMessage = "Andmete lugemine ebaõnnestus"
+                    let errorMessage = "Failed to read data"
                     session.invalidate(errorMessage: errorMessage)
                     continuation?.resume(throwing: AuthenticateWithWebEidError.failedToHashData)
                     return
@@ -165,10 +161,10 @@ extension OperationAuthenticateWithWebEID: @MainActor NFCTagReaderSessionDelegat
                     signingCertificate: signingCertificateBytes.base64EncodedString()
                 )
                 continuation?.resume(returning: webEidData)
-                session.alertMessage = "Andmed loetud"
+                session.alertMessage = "Data read"
                 session.invalidate()
             } catch {
-                session.invalidate(errorMessage: "Andmete lugemine ebaõnnestus")
+                session.invalidate(errorMessage: "Failed to read data")
                 continuation?.resume(throwing: error)
             }
         }


### PR DESCRIPTION
**NFC-76** 

- Rewrite NFC iOS libs messages as localization keys for future reuse.

Signed-off-by: Boriss Melikjan <boriss.melikjan@nortal.com>
